### PR TITLE
Add job platform UI and deployment manifests

### DIFF
--- a/.github/workflows/ghcr-build.yml
+++ b/.github/workflows/ghcr-build.yml
@@ -1,0 +1,44 @@
+name: Build and Push Job Platform Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'job-platform/backend/**'
+      - 'job-platform/ui/**'
+      - '.github/workflows/ghcr-build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - image: backend
+            context: job-platform/backend
+            dockerfile: job-platform/backend/Dockerfile
+          - image: frontend
+            context: job-platform/ui
+            dockerfile: job-platform/ui/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest,ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ ansible/inventory/inventories.ini
 *.pem
 terraform*.log
 **local**
+node_modules/
+dist/

--- a/job-platform/README.md
+++ b/job-platform/README.md
@@ -1,0 +1,49 @@
+# Job Platform
+
+This directory contains a minimal example of a job execution platform for Kubernetes.
+
+## Backend
+
+Located in `backend/`, it exposes a FastAPI service with endpoints to list job templates, run a job, check status, and fetch logs. Job definitions are rendered from Jinja templates and submitted to the Kubernetes cluster.
+
+### Running locally
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Templates
+
+Templates reside in `backend/templates/` and are written in Jinja2.
+
+## UI
+
+The `ui/` directory contains a small React application built with Vite that can submit jobs and poll for status and logs.
+
+```bash
+cd ui
+npm install
+npm run build
+```
+
+## Building Images
+
+Example Dockerfiles are provided for the frontend and backend. Build and push images to a registry accessible by your cluster:
+
+```bash
+# from job-platform/
+docker build -t YOUR_REGISTRY/job-platform-backend:latest backend/
+docker build -t YOUR_REGISTRY/job-platform-frontend:latest ui/
+docker push YOUR_REGISTRY/job-platform-backend:latest
+docker push YOUR_REGISTRY/job-platform-frontend:latest
+```
+
+## Deploying to Kubernetes
+
+Manifests under `deploy/` create Deployments, Services, and an Ingress. Update image references and hostnames, then apply:
+
+```bash
+kubectl apply -f deploy/
+```

--- a/job-platform/README.md
+++ b/job-platform/README.md
@@ -40,6 +40,10 @@ docker push YOUR_REGISTRY/job-platform-backend:latest
 docker push YOUR_REGISTRY/job-platform-frontend:latest
 ```
 
+### GitHub Actions
+
+Container images for the frontend and backend are built automatically and published to GitHub Container Registry on pushes to `main`. The workflow definition lives at `.github/workflows/ghcr-build.yml`.
+
 ## Deploying to Kubernetes
 
 Manifests under `deploy/` create Deployments, Services, and an Ingress. Update image references and hostnames, then apply:

--- a/job-platform/README.md
+++ b/job-platform/README.md
@@ -47,3 +47,8 @@ Manifests under `deploy/` create Deployments, Services, and an Ingress. Update i
 ```bash
 kubectl apply -f deploy/
 ```
+
+## FluxCD Deployment
+
+Flux manifests live under `k3s/apps/base/job-platform`. Add `../base/job-platform` to your environment's `kustomization.yaml` (e.g., `k3s/apps/production/kustomization.yaml`) so FluxCD can reconcile and deploy the frontend, backend, and ingress.
+

--- a/job-platform/backend/Dockerfile
+++ b/job-platform/backend/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/job-platform/backend/requirements.txt
+++ b/job-platform/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+jinja2
+kubernetes
+PyYAML

--- a/job-platform/backend/templates/my-job.yaml.j2
+++ b/job-platform/backend/templates/my-job.yaml.j2
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ job_name }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: {{ params.container_name }}
+        image: {{ params.image }}
+        command: {{ params.command }}
+        env:
+{% for key, value in params.env.items() %}
+        - name: {{ key }}
+          value: {{ value }}
+{% endfor %}
+      restartPolicy: Never
+  backoffLimit: 0

--- a/job-platform/backend/watchers.py
+++ b/job-platform/backend/watchers.py
@@ -1,0 +1,25 @@
+import threading
+from typing import Dict
+from kubernetes import client, watch
+
+
+def start_job_watcher(job_name: str, namespace: str, store: Dict[str, Dict[str, str]]):
+    """Launch a thread to watch a Kubernetes Job and update the provided store."""
+    thread = threading.Thread(
+        target=_watch_job, args=(job_name, namespace, store), daemon=True
+    )
+    thread.start()
+
+
+def _watch_job(job_name: str, namespace: str, store: Dict[str, Dict[str, str]]):
+    w = watch.Watch()
+    batch_api = client.BatchV1Api()
+    for event in w.stream(batch_api.list_namespaced_job, namespace=namespace):
+        job = event["object"]
+        if job.metadata.name == job_name:
+            if job.status.succeeded:
+                store[job_name] = {"status": "succeeded"}
+                w.stop()
+            elif job.status.failed:
+                store[job_name] = {"status": "failed"}
+                w.stop()

--- a/job-platform/deploy/backend.yaml
+++ b/job-platform/deploy/backend.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-platform-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: job-platform-backend
+  template:
+    metadata:
+      labels:
+        app: job-platform-backend
+    spec:
+      containers:
+      - name: backend
+        image: YOUR_REGISTRY/job-platform-backend:latest
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-platform-backend
+spec:
+  selector:
+    app: job-platform-backend
+  ports:
+  - port: 80
+    targetPort: 8000

--- a/job-platform/deploy/frontend.yaml
+++ b/job-platform/deploy/frontend.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-platform-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: job-platform-frontend
+  template:
+    metadata:
+      labels:
+        app: job-platform-frontend
+    spec:
+      containers:
+      - name: frontend
+        image: YOUR_REGISTRY/job-platform-frontend:latest
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-platform-frontend
+spec:
+  selector:
+    app: job-platform-frontend
+  ports:
+  - port: 80
+    targetPort: 80

--- a/job-platform/deploy/ingress.yaml
+++ b/job-platform/deploy/ingress.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: job-platform
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  tls:
+  - hosts:
+    - jobs.example.com
+    secretName: job-platform-tls
+  rules:
+  - host: jobs.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: job-platform-frontend
+            port:
+              number: 80
+      - path: /api
+        pathType: Prefix
+        backend:
+          service:
+            name: job-platform-backend
+            port:
+              number: 80

--- a/job-platform/ui/Dockerfile
+++ b/job-platform/ui/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html

--- a/job-platform/ui/index.html
+++ b/job-platform/ui/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Job Platform</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/job-platform/ui/package.json
+++ b/job-platform/ui/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "job-platform-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/job-platform/ui/src/App.jsx
+++ b/job-platform/ui/src/App.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+
+function App() {
+  const [image, setImage] = useState('')
+  const [command, setCommand] = useState('')
+  const [job, setJob] = useState('')
+  const [status, setStatus] = useState('')
+  const [log, setLog] = useState('')
+
+  const runJob = async () => {
+    const res = await fetch('/api/jobs/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ template: 'my-job', params: {
+        container_name: 'job',
+        image,
+        command
+      }})
+    })
+    const data = await res.json()
+    setJob(data.job_name)
+    pollStatus(data.job_name)
+  }
+
+  const pollStatus = (jobName) => {
+    const interval = setInterval(async () => {
+      const res = await fetch(`/api/jobs/${jobName}/status`)
+      const data = await res.json()
+      setStatus(data.status)
+      if (data.status === 'succeeded' || data.status === 'failed') {
+        clearInterval(interval)
+        const logRes = await fetch(`/api/jobs/${jobName}/logs`)
+        const logData = await logRes.json()
+        setLog(logData.log)
+      }
+    }, 1000)
+  }
+
+  return (
+    <div>
+      <h1>Run Job</h1>
+      <input
+        placeholder="Image"
+        value={image}
+        onChange={e => setImage(e.target.value)}
+      />
+      <input
+        placeholder="Command"
+        value={command}
+        onChange={e => setCommand(e.target.value)}
+      />
+      <button onClick={runJob}>Run</button>
+      {job && <div>Job: {job}</div>}
+      {status && <div>Status: {status}</div>}
+      {log && <pre>{log}</pre>}
+    </div>
+  )
+}
+
+export default App

--- a/job-platform/ui/src/main.jsx
+++ b/job-platform/ui/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/job-platform/ui/vite.config.js
+++ b/job-platform/ui/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8000'
+    }
+  }
+})

--- a/k3s/apps/base/job-platform/backend.yaml
+++ b/k3s/apps/base/job-platform/backend.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-platform-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: job-platform-backend
+  template:
+    metadata:
+      labels:
+        app: job-platform-backend
+    spec:
+      containers:
+      - name: backend
+        image: YOUR_REGISTRY/job-platform-backend:latest
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-platform-backend
+spec:
+  selector:
+    app: job-platform-backend
+  ports:
+  - port: 80
+    targetPort: 8000

--- a/k3s/apps/base/job-platform/frontend.yaml
+++ b/k3s/apps/base/job-platform/frontend.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-platform-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: job-platform-frontend
+  template:
+    metadata:
+      labels:
+        app: job-platform-frontend
+    spec:
+      containers:
+      - name: frontend
+        image: YOUR_REGISTRY/job-platform-frontend:latest
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-platform-frontend
+spec:
+  selector:
+    app: job-platform-frontend
+  ports:
+  - port: 80
+    targetPort: 80

--- a/k3s/apps/base/job-platform/ingress.yaml
+++ b/k3s/apps/base/job-platform/ingress.yaml
@@ -1,0 +1,33 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: job-platform
+  labels:
+    app.kubernetes.io/name: job-platform
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: jobs.joshgeissler.com
+    cert-manager.io/cluster-issuer: letsencrypt-production
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - jobs.joshgeissler.com
+      secretName: job-platform-tls
+  rules:
+    - host: jobs.joshgeissler.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: job-platform-frontend
+                port:
+                  number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: job-platform-backend
+                port:
+                  number: 80

--- a/k3s/apps/base/job-platform/kustomization.yaml
+++ b/k3s/apps/base/job-platform/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: job-platform
+resources:
+  - namespace.yaml
+  - backend.yaml
+  - frontend.yaml
+  - ingress.yaml

--- a/k3s/apps/base/job-platform/namespace.yaml
+++ b/k3s/apps/base/job-platform/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: job-platform
+  labels:
+    toolkit.fluxcd.io/tenant: sre-team

--- a/k3s/apps/production/kustomization.yaml
+++ b/k3s/apps/production/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   # - ../base/dev-apps
   # - ../base/backstage
   - ../base/homepage
+  - ../base/job-platform


### PR DESCRIPTION
## Summary
- extend backend with API router and status-aware watcher
- scaffold React-based frontend for running and monitoring jobs
- provide Dockerfiles and Kubernetes manifests for backend, frontend, and ingress

## Testing
- `pytest`
- `npm install` *(fails: 403 Forbidden fetching packages)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6893adb882d483309741ed1cfe13228b